### PR TITLE
Fix default value for the history file

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -95,7 +95,9 @@ if __name__ == '__main__':
     parser.add_argument('--history-dir', type=str, default="data")
     parser.add_argument('--analysis-dir', type=str, default="analysis")
     parser.add_argument('--plots-dir', type=str, default="plots")
-    parser.add_argument('--history-file', type=str, default="~/.zsh_history")
+    home_dir = os.environ.get("HOME","~")
+    parser.add_argument('--history-file', type=str,
+                        default="%s/.zsh_history" % home_dir)
 
     subparsers = parser.add_subparsers(help='sub-command help', dest='cmd')
     subparsers.required = True


### PR DESCRIPTION
The default value for the history file (`~/.zsh_history`) was
not expanded, resulting in a `FileNotFoundError`.

```python-traceback
Traceback (most recent call last):
  File "analyze.py", line 117, in <module>
    shutil.copyfile(args.history_file, os.path.join(args.history_dir, 'history'))
  File "/i/love/potatoes/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '~/.zsh_history'
```

This commit fix this by taking the values of `HOME` directly.